### PR TITLE
Refactor serial init

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ JP1  |JP2  |Description
 -----|-----|------------------------------
   O  |  O  | 3-button Logitech mouse
   X  |  O  | 2-button Microsoft mouse
-  O  |  X  | Microsoft Wheel Mouse
-  X  |  X  | Undefined
+  O  |  X  | Wheel mouse (cutemouse driver required)
+  X  |  X  | Undefined (2-button mode will override)
 
 ## Bill of materials
 

--- a/README.md
+++ b/README.md
@@ -52,14 +52,15 @@ Cute Mouse Driver is part of FreeDos project and is free and open source.
 ## Jumper Settings
 
 There are two jumpers, which can be used to set different modes. Currently you
-can choose between 2- and 3-button and wheel mouse modes. In the table below, O means open or unset and X means closed or set. The KVM Hack mode is an experimental mode where the PS2 mouse is not reset, but assumed to be initialized and in stream mode. This is done to work around incompatibilities with some KVM switches. 
+can choose between 2-button, 3-button, and wheel mouse modes. In the table below, 
+O means open or unset, and X means closed or set.  
 
 JP1  |JP2  |Description
 -----|-----|------------------------------
   O  |  O  | 3-button Logitech mouse
   X  |  O  | 2-button Microsoft mouse
   O  |  X  | Microsoft Wheel Mouse
-  X  |  X  | KVM Hack with 3-button Logitech mouse
+  X  |  X  | Undefined
 
 ## Bill of materials
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ Cute Mouse Driver is part of FreeDos project and is free and open source.
 ## Jumper Settings
 
 There are two jumpers, which can be used to set different modes. Currently you
-can choose between 2-button, 3-button, and wheel mouse modes. In the table below, 
-O means open or unset, and X means closed or set.  
+can choose between 2-button, 3-button, and wheel mouse modes. In the table below, O means open or unset, and X means closed or set.  
 
 JP1  |JP2  |Description
 -----|-----|------------------------------

--- a/firmware/ps2adapter/Ps2Mouse.cpp
+++ b/firmware/ps2adapter/Ps2Mouse.cpp
@@ -225,13 +225,16 @@ bool Ps2Mouse::recvByte(byte& value) const {
     parity ^= nextBit;
   }
 
-  // Receive and check parity bit
-  recvBit(); // TODO check parity
+  // Receive parity bit
+  byte actualParity = recvBit();
+  if (parity != actualParity) {
+    Serial.println("P!");
+  }
 
   // Receive stop bit
   recvBit();
 
-  return true;
+  return parity == actualParity;
 }
 
 bool Ps2Mouse::recvData(byte* data, size_t size) const {

--- a/firmware/ps2adapter/Ps2Mouse.cpp
+++ b/firmware/ps2adapter/Ps2Mouse.cpp
@@ -3,21 +3,6 @@
 
 namespace {
 
-struct Status {
-
-  byte rightButton   : 1;
-  byte middleButton  : 1;
-  byte leftButton    : 1;
-  byte na2           : 1;
-  byte scaling       : 1;
-  byte dataReporting : 1;
-  byte remoteMode    : 1;
-  byte na1           : 1;
-
-  byte resolution;
-  byte sampleRate;
-};
-
 struct Packet {
 
   byte leftButton    : 1;
@@ -34,25 +19,9 @@ struct Packet {
   byte wheelData;
 };
 
-enum class Command {
-  disableScaling        = 0xE6,
-  enableScaling         = 0xE7,
-  setResolution         = 0xE8,
-  statusRequest         = 0xE9,
-  setStreamMode         = 0xEA,
-  readData              = 0xEB,
-  resetWrapMode         = 0xEC, // Not implemented
-  setWrapMode           = 0xEE, // Not implemented
-  reset                 = 0xFF,
-  setRemoteMode         = 0xF0,
-  getDeviceId           = 0xF2, // Not implemented
-  setSampleRate         = 0xF3,
-  enableDataReporting   = 0xF4,
-  disableDataReporting  = 0xF5,
-  setDefaults           = 0xF6, // Not implemented
-};
 
 enum class Response {
+
   isMouse        = 0x00,
   isWheelMouse   = 0x03,
   selfTestPassed = 0xAA,
@@ -63,232 +32,89 @@ enum class Response {
 
 } // namespace
 
-struct Ps2Mouse::Impl {
-  const Ps2Mouse& m_ref;
-
-  void sendBit(int value) const {
-    while (PS2_READCLOCK != LOW) {}
-    PS2_SETDATA(value);
-    while (PS2_READCLOCK != HIGH) {}
-  }
-
-  int recvBit() const {
-    while (PS2_READCLOCK != LOW) {}
-    auto result = PS2_READDATA;
-    while (PS2_READCLOCK != HIGH) {}
-    return result;
-  }
-
-  bool sendByte(byte value) const {
-
-    // Inhibit communication
-    PS2_DIRCLOCKOUT;
-    PS2_SETCLOCKLOW;
-    delayMicroseconds(10);
-
-    // Set start bit and release the clock
-    PS2_DIRDATAOUT;
-    PS2_SETDATALOW;
-    PS2_DIRCLOCKIN_UP;
-
-    // Send data bits
-    byte parity = 1;
-    for (auto i = 0; i < 8; i++) {
-      byte nextBit = (value >> i) & 0x01;
-      parity ^= nextBit;
-      sendBit(nextBit);
-    }
-
-    // Send parity bit
-    sendBit(parity);
-
-    // Send stop bit
-    sendBit(1);
-
-    // Enter receive mode and wait for ACK bit
-    PS2_DIRDATAIN;
-    return recvBit() == 0;
-  }
-
-  bool recvByte(byte& value) const {
-
-    // Enter receive mode
-    PS2_DIRCLOCKIN;
-    PS2_DIRDATAIN;
-
-    // Receive start bit
-    if (recvBit() != 0) {
-      return false;
-    }
-
-    // Receive data bits
-    value = 0;
-    byte parity = 1;
-    for (int i = 0; i < 8; i++) {
-      byte nextBit = recvBit();
-      value |= nextBit << i;
-      parity ^= nextBit;
-    }
-
-    // Receive and check parity bit
-    recvBit(); // TODO check parity
-
-    // Receive stop bit
-    recvBit();
-
-    return true;
-  }
-
-  template <typename T>
-  bool sendData(const T& data) const {
-    auto ptr = reinterpret_cast<const byte*>(&data);
-    for (auto i = 0; i < sizeof(data); i++) {
-      if (!sendByte(ptr[i])) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  bool recvData(byte* data, size_t size) const {
-    for (size_t i = 0u; i < size; i++) {
-      if (!recvByte(data[i])) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  bool sendByteWithAck(byte value) const {
-    while (true) {
-      if (sendByte(value)) {
-        byte response;
-        if (recvByte(response)) {
-          if (response == static_cast<byte>(Response::resend)) {
-            continue;
-          }
-          return response == static_cast<byte>(Response::ack);
-        }
-      }
-      return false;
-    }
-  }
-
-  bool sendCommand(Command command) const {
-    return sendByteWithAck(static_cast<byte>(command));
-  }
-
-  bool sendCommand(Command command, byte setting) const {
-    return sendCommand(command) && sendByteWithAck(setting);
-  }
-
-  bool getStatus(Status& status) const {
-    return sendCommand(Command::statusRequest) && recvData((byte*) &status, sizeof(Status));
-  }
-};
 
 Ps2Mouse::Ps2Mouse()
-  : m_stream(false), m_wheelMouse(false)
+  : m_type(MouseType::threeButton)
 {}
 
-bool Ps2Mouse::reset(bool streaming, bool kvmHack) {
-  Impl impl{*this};
+bool Ps2Mouse::reset() {
+  
   byte reply;
 
-  // don't send reset command if we are in kvmHack mode
-  if (!kvmHack) {
-    if (!impl.sendCommand(Command::reset)) {
-        return false;
-    }
+  if (!sendCommand(Command::reset)) {
+      return false;
+  }
 
-    if (!impl.recvByte(reply) || reply != byte(Response::selfTestPassed)) {
-        return false;
-    }
+  if (!recvByte(reply) || reply != byte(Response::selfTestPassed)) {
+      return false;
+  }
 
-    if (!impl.recvByte(reply) || reply != byte(Response::isMouse)) {
-        return false;
-    }
+  if (!recvByte(reply) || reply != byte(Response::isMouse)) {
+      return false;
   }
 
   // Determine if this is a wheel mouse
-  if (!impl.sendCommand(Command::setSampleRate, 200) ||
-      !impl.sendCommand(Command::setSampleRate, 100) ||
-      !impl.sendCommand(Command::setSampleRate, 80) ||
-      !impl.sendCommand(Command::getDeviceId) ||
-      !impl.recvByte(reply)) {
+  if (!sendCommand(Command::setSampleRate, 200) ||
+      !sendCommand(Command::setSampleRate, 100) ||
+      !sendCommand(Command::setSampleRate, 80) ||
+      !sendCommand(Command::getDeviceId) ||
+      !recvByte(reply)) {
       return false;
   }
 
-  m_wheelMouse = (reply == byte(Response::isWheelMouse));
-
-  if (streaming) {
-    // Streaming mode is the default after a reset.
-    m_stream = true;
-    // switch on data reporting
-    return impl.sendCommand(Command::enableDataReporting);
+  if (reply == byte(Response::isWheelMouse)) {
+    m_type = MouseType::wheelMouse;
   }
 
-  return disableStreaming() && impl.sendCommand(Command::enableDataReporting);
+  // switch on data reporting
+  return setReporting(true);
 }
 
-bool Ps2Mouse::enableStreaming() {
-  if (Impl{*this}.sendCommand(Command::setStreamMode)) {
-    m_stream = true;
-    return true;
-  }
-  return false;
+bool Ps2Mouse::setReporting(bool enable) const {
+  
+  return sendCommand(enable ? Command::enableDataReporting : Command::disableDataReporting);
 }
 
-bool Ps2Mouse::disableStreaming() {
-  if (Impl{*this}.sendCommand(Command::setRemoteMode)) {
-    m_stream = false;
-    return true;
-  }
-  return false;
+bool Ps2Mouse::setStreamMode() {
+  
+  return (sendCommand(Command::setStreamMode));
+}
+
+bool Ps2Mouse::setRemoteMode() {
+  
+  return (sendCommand(Command::setRemoteMode));
 }
 
 bool Ps2Mouse::setScaling(bool flag) const {
-  if (m_stream) {
-    Impl{*this}.sendCommand(Command::disableDataReporting);
-  }
-  bool res =  Impl{*this}.sendCommand(flag ? Command::enableScaling : Command::disableScaling);
-  if (m_stream) {
-    Impl{*this}.sendCommand(Command::enableDataReporting);
-  }
+  
+  setReporting(false);
+  bool res =  sendCommand(flag ? Command::enableScaling : Command::disableScaling);
+  setReporting(true);
   return res;
 }
 
 bool Ps2Mouse::setResolution(byte resolution) const {
-  if (m_stream) {
-    Impl{*this}.sendCommand(Command::disableDataReporting);
-  }
-  bool res = Impl{*this}.sendCommand(Command::setResolution, resolution);
-  if (m_stream) {
-    Impl{*this}.sendCommand(Command::enableDataReporting);
-  }
+  
+  setReporting(false);
+  bool res = sendCommand(Command::setResolution, resolution);
+  setReporting(true);
   return res;
 }
 
 bool Ps2Mouse::setSampleRate(byte sampleRate) const {
-  if (m_stream) {
-    Impl{*this}.sendCommand(Command::disableDataReporting);
-  }
-  bool res = Impl{*this}.sendCommand(Command::setSampleRate, sampleRate);
-  if (m_stream) {
-    Impl{*this}.sendCommand(Command::enableDataReporting);
-  }
+  
+  setReporting(false);
+  bool res = sendCommand(Command::setSampleRate, sampleRate);
+  setReporting(true);
   return res;
 }
 
 bool Ps2Mouse::getSettings(Settings& settings) const {
+  
   Status status;
-  if (m_stream) {
-    Impl{*this}.sendCommand(Command::disableDataReporting);
-  }
-  bool res = Impl{*this}.getStatus(status);
-  if (m_stream) {
-    Impl{*this}.sendCommand(Command::enableDataReporting);
-  }
+  setReporting(false);
+  bool res = getStatus(status);
+  setReporting(true);
   if (res) {
     settings.rightBtn = status.rightButton;
     settings.middleBtn = status.middleButton;
@@ -303,26 +129,23 @@ bool Ps2Mouse::getSettings(Settings& settings) const {
   return false;
 }
 
+Ps2Mouse::MouseType Ps2Mouse::getType() const {
+  return m_type;
+}
+
 bool Ps2Mouse::readData(Data& data) const {
 
-  Impl impl{*this};
-
-  if (m_stream) {
-     if (PS2_READCLOCK != LOW) {
-       return false;
-     }
-  }
-  else if (!impl.sendCommand(Command::readData)) {
-    return false;
+  if (PS2_READCLOCK != LOW) {
+     return false;
   }
 
   Packet packet = {0};
-  if (m_wheelMouse) {
-    if (!impl.recvData((byte*)&packet, sizeof(packet))) {
+  if (m_type == MouseType::wheelMouse) {
+    if (!recvData((byte*)&packet, sizeof(packet))) {
       return false;
     }
   } else {
-    if (!impl.recvData((byte*)&packet, sizeof(packet) - 1)) {
+    if (!recvData((byte*)&packet, sizeof(packet) - 1)) {
       return false;
     }
   }
@@ -332,6 +155,117 @@ bool Ps2Mouse::readData(Data& data) const {
   data.rightButton = packet.rightButton;
   data.xMovement = (packet.xSign ? -0x100 : 0) | packet.xMovement;
   data.yMovement = (packet.ySign ? -0x100 : 0) | packet.yMovement;
-  data.wheelMovement = m_wheelMouse ? packet.wheelData : 0;
+  data.wheelMovement = (m_type == MouseType::wheelMouse) ? packet.wheelData : 0;
   return true;
+}
+
+void Ps2Mouse::sendBit(int value) const {
+  
+  while (PS2_READCLOCK != LOW) {}
+  PS2_SETDATA(value);
+  while (PS2_READCLOCK != HIGH) {}
+}
+
+bool Ps2Mouse::sendByte(byte value) const {
+
+  // Inhibit communication
+  PS2_DIRCLOCKOUT;
+  PS2_SETCLOCKLOW;
+  delayMicroseconds(10);
+
+  // Set start bit and release the clock
+  PS2_DIRDATAOUT;
+  PS2_SETDATALOW;
+  PS2_DIRCLOCKIN_UP;
+
+  // Send data bits
+  byte parity = 1;
+  for (auto i = 0; i < 8; i++) {
+    byte nextBit = (value >> i) & 0x01;
+    parity ^= nextBit;
+    sendBit(nextBit);
+  }
+
+  // Send parity bit
+  sendBit(parity);
+
+  // Send stop bit
+  sendBit(1);
+
+  // Enter receive mode and wait for ACK bit
+  PS2_DIRDATAIN;
+  return recvBit() == 0;
+}
+
+int Ps2Mouse::recvBit() const {
+
+  while (PS2_READCLOCK != LOW) {}
+  auto result = PS2_READDATA;
+  while (PS2_READCLOCK != HIGH) {}
+  return result;
+}
+
+bool Ps2Mouse::recvByte(byte& value) const {
+
+  // Enter receive mode
+  PS2_DIRCLOCKIN;
+  PS2_DIRDATAIN;
+
+  // Receive start bit
+  if (recvBit() != 0) {
+    return false;
+  }
+
+  // Receive data bits
+  value = 0;
+  byte parity = 1;
+  for (int i = 0; i < 8; i++) {
+    byte nextBit = recvBit();
+    value |= nextBit << i;
+    parity ^= nextBit;
+  }
+
+  // Receive and check parity bit
+  recvBit(); // TODO check parity
+
+  // Receive stop bit
+  recvBit();
+
+  return true;
+}
+
+bool Ps2Mouse::recvData(byte* data, size_t size) const {
+  for (size_t i = 0u; i < size; i++) {
+    if (!recvByte(data[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool Ps2Mouse::sendByteWithAck(byte value) const {
+  while (true) {
+    if (sendByte(value)) {
+      byte response;
+      if (recvByte(response)) {
+        if (response == static_cast<byte>(Response::resend)) {
+          continue;
+        }
+        return response == static_cast<byte>(Response::ack);
+      }
+    }
+    return false;
+  }
+}
+
+bool Ps2Mouse::sendCommand(Command command) const {
+  return sendByteWithAck(static_cast<byte>(command));
+}
+
+bool Ps2Mouse::sendCommand(Command command, byte setting) const {
+  return sendCommand(command) && sendByteWithAck(setting);
+}
+
+bool Ps2Mouse::getStatus(Status& status) const {
+  return sendCommand(Command::statusRequest) && recvData((byte*) &status, sizeof(Status));
 }

--- a/firmware/ps2adapter/Ps2Mouse.h
+++ b/firmware/ps2adapter/Ps2Mouse.h
@@ -5,7 +5,14 @@
 class Ps2Mouse {
 public:
 
+  enum class MouseType {
+
+    threeButton,
+    wheelMouse,
+  };
+
   struct Data {
+
     bool leftButton;
     bool middleButton;
     bool rightButton;
@@ -15,6 +22,7 @@ public:
   };
 
   struct Settings {
+    
     bool rightBtn;
     bool middleBtn;
     bool leftBtn;
@@ -27,21 +35,65 @@ public:
 
   Ps2Mouse();
 
-  bool reset(bool streaming, bool kvmHack);
+  bool reset();
+  bool setReporting(bool enable) const;
+
+  bool setStreamMode();
+  bool setRemoteMode();
 
   bool setScaling(bool flag) const;
   bool setResolution(byte resolution) const;
   bool setSampleRate(byte sampleRate) const;
 
   bool getSettings(Settings& settings) const;
+  Ps2Mouse::MouseType getType() const;
 
-  bool enableStreaming();
-  bool disableStreaming();
   bool readData(Data& data) const;
 
 private:
-  struct Impl;
+  enum class Command {
 
-  bool m_stream;
-  bool m_wheelMouse;
+    disableScaling        = 0xE6,
+    enableScaling         = 0xE7,
+    setResolution         = 0xE8,
+    statusRequest         = 0xE9,
+    setStreamMode         = 0xEA,
+    readData              = 0xEB,
+    resetWrapMode         = 0xEC, // Not implemented
+    setWrapMode           = 0xEE, // Not implemented
+    reset                 = 0xFF,
+    setRemoteMode         = 0xF0,
+    getDeviceId           = 0xF2, // Not implemented
+    setSampleRate         = 0xF3,
+    enableDataReporting   = 0xF4,
+    disableDataReporting  = 0xF5,
+    setDefaults           = 0xF6, // Not implemented
+  };
+
+  struct Status {
+
+    byte rightButton   : 1;
+    byte middleButton  : 1;
+    byte leftButton    : 1;
+    byte na2           : 1;
+    byte scaling       : 1;
+    byte dataReporting : 1;
+    byte remoteMode    : 1;
+    byte na1           : 1;
+
+    byte resolution;
+    byte sampleRate;
+  };
+
+  void sendBit(int value) const;
+  int recvBit() const;
+  bool sendByte(byte value) const;
+  bool recvByte(byte& value) const;
+  bool recvData(byte* data, size_t size) const;
+  bool sendByteWithAck(byte value) const;
+  bool sendCommand(Command command) const;
+  bool sendCommand(Command command, byte setting) const;
+  bool getStatus(Status& status) const;
+
+  MouseType m_type;
 };

--- a/firmware/ps2adapter/ps2adapter.ino
+++ b/firmware/ps2adapter/ps2adapter.ino
@@ -48,7 +48,7 @@ static void sendToSerial(const Ps2Mouse::Data& data) {
     byte mb;
     if (wheelMouse) {
       // according to: https://sourceforge.net/p/cutemouse/trunk/ci/master/tree/cutemouse/PROTOCOL.TXT
-      // the middle button should be reported in bit 0x10 for a wheel mouse
+      // for a wheel mouse, the middle button should be reported in bit 0x10
       mb = data.middleButton ? 0x10 : 0;
       mb |= (data.wheelMovement & 0x0F);
     } else {

--- a/firmware/ps2adapter/ps2adapter.ino
+++ b/firmware/ps2adapter/ps2adapter.ino
@@ -6,7 +6,8 @@ static const int RS232_RTS = 3;
 static Ps2Mouse mouse;
 static bool twoButtons = false;
 static bool wheelMouse = false;
-static bool kvmHack = false;
+static volatile bool doSerialInit = false;
+static volatile bool serialInitDone = false;
 
 static void sendSerialBit(int data) {
   // Delay between the signals to match 1200 baud
@@ -35,6 +36,7 @@ static void sendSerialByte(byte data) {
 }
 
 static void sendToSerial(const Ps2Mouse::Data& data) {
+
   auto dx = constrain(data.xMovement, -127, 127);
   auto dy = constrain(-data.yMovement, -127, 127);
   byte lb = data.leftButton ? 0x20 : 0;
@@ -55,14 +57,18 @@ static void sendToSerial(const Ps2Mouse::Data& data) {
 }
 
 static void initSerialPort() {
+
   Serial.println("Starting serial port");
   RS_SETTXHIGH;
   delayMicroseconds(10000);
   sendSerialByte('M');
   if(!twoButtons) {
-    if(wheelMouse) {
+    // if wheelMouse mode has been set by jumper, confirm that the mouse has the capability
+    if(wheelMouse && (mouse.getType() == Ps2Mouse::MouseType::wheelMouse)) {
+      // set wheelMouse mode
       sendSerialByte('Z');
     } else {
+      // set 3-button (Logitech) mode
       sendSerialByte('3');
     }
     Serial.println(wheelMouse ? "Init Wheel mode" : "Init 3-button mode");
@@ -70,16 +76,17 @@ static void initSerialPort() {
     Serial.println("Init 2-button mode");
   }
   delayMicroseconds(10000);
-
-  Serial.println("Listening on RTS");
-  void (*resetHack)() = 0;
-  attachInterrupt(digitalPinToInterrupt(RS232_RTS), resetHack, FALLING);
+  // Renable PS/2 mouse data reporting
+  mouse.setReporting(true);
+  // Signal the main loop that the serial port is ready
+  serialInitDone = true;
 }
 
 static void initPs2Port() {
+
   Serial.println("Reseting PS/2 mouse");
   
-  if (mouse.reset(true, kvmHack)) {
+  if (mouse.reset()) {
     Serial.println("PS/2 mouse reset OK");
   } else {
     Serial.println("Failed to reset PS/2 mouse");
@@ -104,6 +111,15 @@ static void initPs2Port() {
   }
 }
 
+void resetSerialSignal() {
+  // signal the main loop to ignore the PS/2 mouse data until the serial port is ready
+  serialInitDone = false;
+  // disable the PS/2 mouse data reporting while the serial port is being initialized
+  mouse.setReporting(false);
+  // signal the main loop to initialize the serial port
+  doSerialInit = true;
+}
+
 void setup() {
   // PS/2 Data input must be initialized shortly after power on,
   // or the mouse will not initialize
@@ -113,25 +129,30 @@ void setup() {
   JP34_DIRIN_UP;
   LED_DIROUT;
   LED_SET(HIGH);
+
   Serial.begin(115200);
   twoButtons = (JP12_READ == LOW);
   wheelMouse = (JP34_READ == LOW);
-  if (wheelMouse && twoButtons) {
-    twoButtons = false;
-    wheelMouse = false;
-    kvmHack = true;
-    Serial.println("KVM hack enabled");
-  }
-  initSerialPort();
+
+  // PS/2 initialization can take > 400ms for reset to complete.
+  // Init the mouse here, determine it's characteristics and then
+  // wait for the RTS signal to initialize the serial port comms
   initPs2Port();
+  Serial.println("Listening on RTS");
+  attachInterrupt(digitalPinToInterrupt(RS232_RTS), resetSerialSignal, FALLING);
+
   Serial.println("Setup done!");
   LED_SETLOW;
 }
 
 
 void loop() {
+  if (doSerialInit) {
+    initSerialPort();
+    doSerialInit = false;
+  }
   Ps2Mouse::Data data;
-  if (mouse.readData(data)) {
+  if (serialInitDone && mouse.readData(data)) {
     sendToSerial(data);
   }
 }

--- a/firmware/ps2adapter/ps2adapter.ino
+++ b/firmware/ps2adapter/ps2adapter.ino
@@ -47,9 +47,12 @@ static void sendToSerial(const Ps2Mouse::Data& data) {
   if (!twoButtons) {
     byte mb;
     if (wheelMouse) {
+      // according to: https://sourceforge.net/p/cutemouse/trunk/ci/master/tree/cutemouse/PROTOCOL.TXT
+      // the middle button should be reported in bit 0x10 for a wheel mouse
       mb = data.middleButton ? 0x10 : 0;
       mb |= (data.wheelMovement & 0x0F);
     } else {
+      // for a 3-button mouse, the middle button should be reported in bit 0x20
       mb = data.middleButton ? 0x20 : 0;
     }
     sendSerialByte(mb);

--- a/firmware/ps2adapter/ps2adapter.ino
+++ b/firmware/ps2adapter/ps2adapter.ino
@@ -70,11 +70,12 @@ static void initSerialPort() {
     if(wheelMouse && (mouse.getType() == Ps2Mouse::MouseType::wheelMouse)) {
       // set wheelMouse mode
       sendSerialByte('Z');
+      Serial.println("Init wheel mode");
     } else {
       // set 3-button (Logitech) mode
       sendSerialByte('3');
+      Serial.println("Init 3-button mode");
     }
-    Serial.println(wheelMouse ? "Init Wheel mode" : "Init 3-button mode");
   } else {
     Serial.println("Init 2-button mode");
   }


### PR DESCRIPTION
Fairly large restructuring of the code:

*   Took a different philosophical take on the serial init logic, initializing the mouse first and then serial on RTS signal.
*   Moved the impl functionality into the mouse class (this looks cleaner, at least to me in terms of using that code in Ps2Mouse). 
*   Added parity checking in the Ps2 code.